### PR TITLE
GH-8,GH-9: Ginkgo test failure propagate to GUT fix

### DIFF
--- a/pkg/gdnative/convertvariant.go
+++ b/pkg/gdnative/convertvariant.go
@@ -21,7 +21,7 @@ func VariantToGoType(variant Variant) reflect.Value {
 	case GODOT_VARIANT_TYPE_REAL:
 		return reflect.ValueOf(variant.AsReal())
 	case GODOT_VARIANT_TYPE_STRING:
-		return reflect.ValueOf(variant.AsString())
+		return reflect.ValueOf(internWithGodotString(variant.AsString()))
 	case GODOT_VARIANT_TYPE_VECTOR2:
 		return reflect.ValueOf(variant.AsVector2())
 	case GODOT_VARIANT_TYPE_RECT2:
@@ -99,7 +99,7 @@ func GoTypeToVariant(value reflect.Value) Variant {
 	case string:
 		return NewVariantString(v)
 	case String:
-		return NewVariantString(v.AsGoString())
+		return NewVariantString(internWithGodotString(v))
 	case Vector2:
 		return NewVariantVector2(v)
 	case Rect2:

--- a/test/pkg/gdnativetest/object_player_character.go
+++ b/test/pkg/gdnativetest/object_player_character.go
@@ -34,23 +34,22 @@ func (p *PlayerCharacter) BaseClass() string {
 // RandomTeleport teleports the player to a random location within the range of distance.
 func (p *PlayerCharacter) RandomTeleport(distance float64) {
 	pos := p.GetPosition()
-	v := gdnative.NewVector2(rand.Float32() - 0.5, rand.Float32() - 0.5)
+	v := gdnative.NewVector2(rand.Float32()-0.5, rand.Float32()-0.5)
 	normalized := v.Normalized()
 	p.SetPosition(pos.OperatorAdd(normalized.OperatorMultiplyScalar(float32(distance))))
 }
 
 func randomString(len int) string {
-	randomInt := func (min, max int) int {
+	randomInt := func(min, max int) int {
 		return min + rand.Intn(max-min)
 	}
 
-    bytes := make([]byte, len)
-    for i := 0; i < len; i++ {
-        bytes[i] = byte(randomInt(65, 90))
-    }
-    return string(bytes)
+	bytes := make([]byte, len)
+	for i := 0; i < len; i++ {
+		bytes[i] = byte(randomInt(65, 90))
+	}
+	return string(bytes)
 }
-
 
 // RandomName generates a random 10 character string to assign as the player's name.
 func (p *PlayerCharacter) RandomName() {
@@ -83,8 +82,10 @@ func (p *PlayerCharacter) OnClassRegistered(e gdnative.ClassRegisteredEvent) {
 }
 
 // RunGinkgoTestSuite is the entrypoint for the ginkgo test suite
-func (p *PlayerCharacter) RunGinkgoTestSuite() {
-	runTests()
+func (p *PlayerCharacter) RunGinkgoTestSuite() gdnative.Variant {
+	ret := runTests()
+
+	return gdnative.NewVariantBool(ret)
 }
 
 // GetVelocity returns the velocity to Godot
@@ -206,7 +207,7 @@ func (p *PlayerCharacter) updateSprite(delta float64) {
 	} else if ca != "" {
 		tokens := strings.Split(ca, "-")
 
-		if len(tokens) != 2  {
+		if len(tokens) != 2 {
 			log.Panic("unable to parse animation name", gdnative.StringField("name", ca))
 		}
 
@@ -268,7 +269,7 @@ func NewPlayerCharacter() PlayerCharacter {
 
 var (
 	defaultVelocity gdnative.Variant
-	defaultName gdnative.Variant
+	defaultName     gdnative.Variant
 )
 
 // PlayerCharacterNativescriptInit called after NativeScript initializes

--- a/test/pkg/gdnativetest/testsuite.go
+++ b/test/pkg/gdnativetest/testsuite.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func runTests() {
+func runTests() bool {
 	isSet := func(name string) bool {
 		v, _ := os.LookupEnv(name)
 		return v == "1"
@@ -30,5 +30,5 @@ func runTests() {
 	}
 
 	RegisterFailHandler(Fail)
-	RunSpecs(GinkgoT(), "Godot Integration Test Suite")
+	return RunSpecs(GinkgoT(), "Godot Integration Test Suite")
 }

--- a/test/pkg/gdnativetest/variant_spec.go
+++ b/test/pkg/gdnativetest/variant_spec.go
@@ -92,7 +92,7 @@ var _ = Describe("Variant", func() {
 			Ω(rf.Interface()).Should(Equal(f))
 
 			rs := gdnative.VariantToGoType(arr.Get(1))
-			Ω(rs.Interface()).Should(Equal(str))
+			Ω(rs.Interface()).Should(Equal("my name"))
 		})
 
 		It("should return an Object type", func() {

--- a/test/test/unit/test_player_character.gd
+++ b/test/test/unit/test_player_character.gd
@@ -31,5 +31,5 @@ func test_player_characater_name():
 
 func test_run_go_ginkgo_testsuite():
 	var inst = PlayerCharacter.new()
-	inst.run_ginkgo_testsuite()
+	assert_true(inst.run_ginkgo_testsuite())
 	inst.free()


### PR DESCRIPTION
* `VariantToGoType` and `GoTypeToVariant` now accepts and return native go strings.