### PR TITLE
fix: address PR review feedback on class instance lifecycle refactor

### DIFF
--- a/openspec/changes/archive/2026-08-03-upgrade-create-instance-to-v3-api/design.md
+++ b/openspec/changes/archive/2026-08-03-upgrade-create-instance-to-v3-api/design.md
@@ -70,7 +70,7 @@ During implementation, two blockers were discovered:
 **Resolution:** The implementation uses:
 - `CreationInfo4` + `RegisterExtensionClass4` for registration (available in the binary)
 - C string as `class_userdata` (avoids the g0 crash)
-- String-based `CreateGDClassInstance2(tn string)` called from the callback (avoids the g0 crash by using the origin/main `WrappedPostInitialize2` path which handles `Pinner.Pin` correctly)
+- String-based `CreateGDClassInstance2(tn string)` called from the callback (avoids the g0 crash by using the origin/main `WrappedPostInitialize` path which handles `Pinner.Pin` correctly)
 - `cgo_classcreationinfo_createinstance2` C function cast as `GDExtensionClassCreateInstance2` type
 
 The `NewGDExtensionClassCreationInfo6` constructor, `ClassUserdata` struct, generic `CreateGDClassInstance[T]`, and `SetConstructInfo` are all defined and available for future use when the blockers are resolved.

--- a/openspec/changes/archive/2026-08-03-upgrade-create-instance-to-v3-api/tasks.md
+++ b/openspec/changes/archive/2026-08-03-upgrade-create-instance-to-v3-api/tasks.md
@@ -6,7 +6,7 @@
 
 ## 2. Instance Lifecycle Refactor
 
-- [x] 2.1 Add `SetConstructInfo` function in `pkg/builtin/wrapped_gdclass.go` matching godot-cpp pattern (no pnr.Pin calls)
+- [x] 2.1 Add `SetConstructInfo` function in `pkg/builtin/wrapped_gdclass.go` matching godot-cpp pattern (with pnr.Pin on cbs)
 - [x] 2.2 Add generic `CreateGDClassInstance[T GDClass]() T` using `SetConstructInfo`
 - [x] 2.3 Add string-based `CreateGDClassInstance2(tn string) GDClass` using `WrappedPostInitialize`
 - [x] 2.4 Restore `WrappedPostInitialize` with pnr.Pin calls (compat for CreateInstance2 callback)
@@ -22,8 +22,8 @@
 ## 4. Build Configuration
 
 - [x] 4.1 Add `GOAMD64=v3` to build targets (caps Go compiler at AVX2)
-- [x] 4.2 Add `-ldflags="-X runtime.godebugDefault=cpu.avx512f=off"` to disable AVX-512 in Go runtime
-- [x] 4.3 Restore test target (no valgrind), add `build-asan` and `test-asan` targets
+- [ ] 4.2 Add `-ldflags="-X runtime.godebugDefault=cpu.avx512f=off"` to disable AVX-512 in Go runtime (deferred — `GOAMD64=v3` is used instead via CGO_CFLAGS)
+- [ ] 4.3 Add `build-asan` and `test-asan` Makefile targets (deferred)
 - [x] 4.4 Add `vgcore.*` to `.gitignore`
 
 ## 5. Bug Fixes

--- a/pkg/builtin/wrapped.go
+++ b/pkg/builtin/wrapped.go
@@ -44,42 +44,6 @@ func (w *WrappedImpl) IsNil() bool {
 func (w *WrappedImpl) Destroy() {
 }
 
-// NewWrapped creates a new WrappedImpl and its underlying GodotObject.
-// Wrapped::Wrapped(const StringName &p_godot_class) in godot-cpp
-// func NewWrappedFromClassName(className string) *WrappedImpl {
-// 	log.Debug("NewWrappedFromClassName called")
-// 	snclassName := NewStringNameWithLatin1Chars(className)
-// 	defer snclassName.Destroy()
-// 	snClassNamePtr := snclassName.AsGDExtensionConstStringNamePtr()
-// 	owner := CallFunc_GDExtensionInterfaceClassdbConstructObject2(snClassNamePtr)
-// 	w := &WrappedImpl{
-// 		Owner: (*GodotObject)(unsafe.Pointer(owner)),
-// 	}
-// 	instHandle := cgo.NewHandle(w)
-
-// 	cbs, ok := GDExtensionBindingGDExtensionInstanceBindingCallbacks.Get(className)
-// 	if !ok {
-// 		log.Warn("unable to find callbacks for Object",
-// 			zap.String("name", className),
-// 		)
-// 		return nil
-// 	}
-
-// 	// Set the extension instance in the native Godot object.
-// 	CallFunc_GDExtensionInterfaceObjectSetInstance(
-// 		(GDExtensionObjectPtr)(owner),
-// 		(GDExtensionConstStringNamePtr)(snClassNamePtr),
-// 		(GDExtensionClassInstancePtr)(instHandle),
-// 	)
-// 	CallFunc_GDExtensionInterfaceObjectSetInstanceBinding(
-// 		(GDExtensionObjectPtr)(owner),
-// 		unsafe.Pointer(FFI.Token),
-// 		instHandle,
-// 		&cbs,
-// 	)
-// 	return w
-// }
-
 // NewWrappedFromGodotObject creates a new WrappedImpl from an existing GodotObject..
 //
 //	Wrapped::Wrapped(GodotObject *p_godot_object) in godot-cpp

--- a/pkg/builtin/wrapped_gdclass.go
+++ b/pkg/builtin/wrapped_gdclass.go
@@ -47,6 +47,7 @@ func SetConstructInfo(w Wrapped, extensionClassName string, cbs ffi.GDExtensionI
 	defer snExtensionClassName.Destroy()
 	cnPtr := snExtensionClassName.AsGDExtensionConstStringNamePtr()
 	instHandle := cgo.NewHandle(w)
+	pnr.Pin(&cbs)
 
 	// Set the extension instance in the native Godot object.
 	CallFunc_GDExtensionInterfaceObjectSetInstance(
@@ -90,6 +91,7 @@ func WrappedPostInitialize(extensionClassName string, w Wrapped) {
 	pnr.Pin(owner)
 	pnr.Pin(inst)
 	pnr.Pin(cnPtr)
+	pnr.Pin(&callbacks)
 	instHandle := cgo.NewHandle(inst)
 	if cnPtr != nil {
 		CallFunc_GDExtensionInterfaceObjectSetInstance(

--- a/pkg/builtin/wrapped_gdclass.go
+++ b/pkg/builtin/wrapped_gdclass.go
@@ -53,7 +53,7 @@ func SetConstructInfo(w Wrapped, extensionClassName string, cbs ffi.GDExtensionI
 	CallFunc_GDExtensionInterfaceObjectSetInstance(
 		(GDExtensionObjectPtr)(owner),
 		(GDExtensionConstStringNamePtr)(cnPtr),
-		(GDExtensionClassInstancePtr)(instHandle),
+		(GDExtensionClassInstancePtr)(unsafe.Pointer(instHandle)),
 	)
 	CallFunc_GDExtensionInterfaceObjectSetInstanceBinding(
 		(GDExtensionObjectPtr)(owner),
@@ -97,7 +97,7 @@ func WrappedPostInitialize(extensionClassName string, w Wrapped) {
 		CallFunc_GDExtensionInterfaceObjectSetInstance(
 			(GDExtensionObjectPtr)(owner),
 			cnPtr,
-			(GDExtensionClassInstancePtr)(instHandle),
+			(GDExtensionClassInstancePtr)(unsafe.Pointer(instHandle)),
 		)
 	}
 	CallFunc_GDExtensionInterfaceObjectSetInstanceBinding(

--- a/pkg/core/lib.go
+++ b/pkg/core/lib.go
@@ -47,12 +47,6 @@ func CreateGDClassInstance[T GDClass]() T {
 	className := inst.GetClassName()
 	parentName := inst.GetParentClassName()
 
-	// ci, ok := Internal.GDRegisteredGDClasses.Get(className)
-	// if !ok {
-	// 	log.Panic("type not found",
-	// 		zap.String("name", className),
-	// 	)
-	// }
 	log.Debug("CreateGDClassInstance called",
 		zap.String("class_name", className),
 		zap.Any("parent_name", parentName),


### PR DESCRIPTION
- Pin GDExtensionInstanceBindingCallbacks in SetConstructInfo and WrappedPostInitialize before passing to C (prevents Go 1.25+ cgocheck heap corruption)
- Remove commented-out NewWrappedFromClassName function (dead code)
- Remove commented-out ClassInfo lookup in CreateGDClassInstance
- Fix design.md reference: WrappedPostInitialize2 → WrappedPostInitialize
- Fix tasks.md: uncheck tasks 4.2/4.3 (AVX-512 disable and asan targets were marked complete but never implemented)
- Update task 2.1 description to reflect pnr.Pin inclusion